### PR TITLE
[Bug #32865]: Allow cim direct response delimiter to be specified for authorize.net

### DIFF
--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.52.0.1"
+  VERSION = "1.52.0.2"
 end


### PR DESCRIPTION
https://pm.cyanna.com/issues/32865

After looking at the documentation here: https://support.authorize.net/authkb/index?page=content&id=A680&actp=LIST I noticed that the delimiter can also be specified per transaction. I chose to add this config to AM rather than trying to count backwards through the direct response string. This seems better to me, because after looking at how AM is currently counting through the response array, it wasn't clear to me that the length was predictable, or that there weren't parts to the response after `54`. For example, if there are other parts to the response after 54, but AM just ignores them, our backwards counting mechanism could potentially break.

A good delimiter seems like the approach that we'll have to worry about least in the future (i.e. it's also immune to Authorize.net adding new fields onto the end of direct response (seems unlikely they'd unseat elements at the beginning of the response string).

The docs I linked above only give an example of usage with cim usage, which is why I only added this functionality for cim actions. If we end up submitting this upstream it may be able to be extended to non-cim transactions. Authorize.net's documentation seems to be a  WIP as they move everything to http://developer.authorize.net/api/reference/. The pdf documentation is dead at this point https://www.authorize.net/content/dam/authorize/documents/CIM_XML_guide.pdf.