### PR TITLE
[Bug #32865]: Add cim void delim support

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -312,6 +312,7 @@ module ActiveMerchant #:nodoc:
               xml.transId(transaction_id_from(authorization))
             end
           end
+          add_cim_delimiter_options(xml)
         end
       end
 

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.52.0.3"
+  VERSION = "1.52.0.4"
 end


### PR DESCRIPTION
https://pm.cyanna.com/issues/32865

Part 2. I forgot to add this support for voids. I've tested this branch in EDvera and it works. (I pushed up a new gem version with this change already to use in the related EDvera PR.)